### PR TITLE
feat: add support for using commit hash in tag replacement pattern

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Prefix to strip from the tag. For example if `strip_prefix` is set to `v` and the tag is `v1.0.0` the output becomes `1.0.0`.'
     required: false
     default: ''
+  use_tag_commit_hash:
+    description: 'When true, uses commit hash in the replacement pattern. For example, replaces [hash] #v1 with [hash] #v2.'
+    required: false
+    default: 'false'
 
 outputs:
   is_initial_release:
@@ -58,6 +62,7 @@ runs:
         INPUT_PATTERN: ${{ inputs.pattern }}
         INPUT_ONLY_MAJOR: ${{ inputs.only_major }}
         INPUT_STRIP_PREFIX: ${{ inputs.strip_prefix }}
+        INPUT_USE_TAG_COMMIT_HASH: ${{ inputs.use_tag_commit_hash }}
 
 branding:
   icon: arrow-up

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     required: false
     default: ''
   use_tag_commit_hash:
-    description: 'When true, uses commit hash in the replacement pattern. For example, replaces [hash] #v1 with [hash] #v2.'
+    description: 'When true, uses commit hash in the replacement pattern. For example, replaces `hash # v1` with `hash # v2`.'
     required: false
     default: 'false'
 


### PR DESCRIPTION
- Introduced `use_tag_commit_hash` input to allow users to include commit hashes in the replacement pattern.
- Updated `entrypoint.sh` to handle the new input and adjust the tag replacement logic accordingly.